### PR TITLE
Looks like the Bearer prefix is required for the simplest case of using heroku auth:token

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -20,7 +20,7 @@ module.exports = function(opts) {
 
 	var authorizedPostHeaders = {
 		'Accept': 'application/vnd.heroku+json; version=3',
-		'Authorization': token
+		'Authorization': 'Bearer ' + token
 	};
 
 	logger.info("creating slug tarball");


### PR DESCRIPTION
https://devcenter.heroku.com/articles/platform-api-quickstart
