### PR TITLE
Reduce tarball size by 1.7mb by only including node binary (not npm, everything else)

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -28,7 +28,7 @@ function ensureNodeDownloaded(opts) {
 				logger.info('node already downloaded, using it');
 			} else {
 				logger.info('downloading node');
-				return exec('curl http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz | tar xz', opts); // Download node
+				return exec('curl http://nodejs.org/dist/v0.10.32/node-v0.10.32-linux-x64.tar.gz | tar xz node-v0.10.32-linux-x64/bin/node', opts); // Download node
 			}
 		});
 }


### PR DESCRIPTION
As suggested by @wheresrhys  - closes #14
