### PR TITLE
`tar` exclusion of 'tmp' excludes any directory named `tmp`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -71,13 +71,13 @@ module.exports = function(options) {
 		readFile(opts.cwd+'/.slugignore', 'utf8'),
 		detectUbuntu(strict),
 		ensureNodeDownloaded(opts),
-		exec('mkdir -p tmp', opts)
+		exec('mkdir -p .haikro', opts)
 	])
 		.then(function(results) {
 			logger.info('making tarball');
 			var tarOptions = results[0];
 			var slugContents = results[1];
-			var excludeList = ['--exclude ./tmp'];
+			var excludeList = ['--exclude ./.haikro'];
 
 			// GNU tar <1.28 does not support --exclude-from
 			if (slugContents) {
@@ -88,7 +88,7 @@ module.exports = function(options) {
 				excludeList.push.apply(excludeList, slugIgnores);
 			}
 
-			return exec("tar "+tarOptions+" -f tmp/slug.tgz " + excludeList.join(' ') + " .", opts);
+			return exec("tar "+tarOptions+" -f .haikro/slug.tgz " + excludeList.join(' ') + " .", opts);
 		})
 		.then(function() {
 			logger.info('build finished');

--- a/lib/build.js
+++ b/lib/build.js
@@ -71,13 +71,13 @@ module.exports = function(options) {
 		readFile(opts.cwd+'/.slugignore', 'utf8'),
 		detectUbuntu(strict),
 		ensureNodeDownloaded(opts),
-		exec('mkdir -p .haikro', opts)
+		exec('mkdir -p .haikro-cache', opts)
 	])
 		.then(function(results) {
 			logger.info('making tarball');
 			var tarOptions = results[0];
 			var slugContents = results[1];
-			var excludeList = ['--exclude ./.haikro'];
+			var excludeList = ['--exclude ./.haikro-cache'];
 
 			// GNU tar <1.28 does not support --exclude-from
 			if (slugContents) {
@@ -88,7 +88,7 @@ module.exports = function(options) {
 				excludeList.push.apply(excludeList, slugIgnores);
 			}
 
-			return exec("tar "+tarOptions+" -f .haikro/slug.tgz " + excludeList.join(' ') + " .", opts);
+			return exec("tar "+tarOptions+" -f .haikro-cache/slug.tgz " + excludeList.join(' ') + " .", opts);
 		})
 		.then(function() {
 			logger.info('build finished');

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -48,7 +48,7 @@ module.exports = function(opts) {
 						throw new Error('cannot create slug, are your heroku access token and app name correct?');
 					}
 					logger.info("uploading slug");
-					return exec("curl -f -X PUT -H 'Content-Type:' --data-binary @tmp/slug.tgz \""+slug.blob.url+"\"", opts)
+					return exec("curl -f -X PUT -H 'Content-Type:' --data-binary @.haikro/slug.tgz \""+slug.blob.url+"\"", opts)
 						.then(function() {
 							logger.info("releasing slug");
 							return fetch("https://api.heroku.com/apps/"+app+"/releases", {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -48,7 +48,7 @@ module.exports = function(opts) {
 						throw new Error('cannot create slug, are your heroku access token and app name correct?');
 					}
 					logger.info("uploading slug");
-					return exec("curl -f -X PUT -H 'Content-Type:' --data-binary @.haikro/slug.tgz \""+slug.blob.url+"\"", opts)
+					return exec("curl -f -X PUT -H 'Content-Type:' --data-binary @.haikro-cache/slug.tgz \""+slug.blob.url+"\"", opts)
 						.then(function() {
 							logger.info("releasing slug");
 							return fetch("https://api.heroku.com/apps/"+app+"/releases", {

--- a/lib/release.js
+++ b/lib/release.js
@@ -17,7 +17,7 @@ module.exports = function(opts) {
 	var authorizedHeaders = { Authorization: 'token '+token };
 
 	logger.verbose("getting all releases");
-	return exists(opts.cwd+'/.haikro/slug.tgz')
+	return exists(opts.cwd+'/.haikro-cache/slug.tgz')
 		.then(function(exists) {
 			if (!exists) throw new Error('cannot find releaseable binary');
 		})
@@ -61,7 +61,7 @@ module.exports = function(opts) {
 				+ " -H 'Accept: application/vnd.github.manifold-preview' "
 				+ " -H 'Content-Type:application/gzip' "
 				+ " -H 'Authorization:"+authorizedHeaders.Authorization+"' "
-				+ " --data-binary @.haikro/slug.tgz "
+				+ " --data-binary @.haikro-cache/slug.tgz "
 				+ " \"https://uploads.github.com/repos/"+repository+"/releases/"+release+"/assets?name="+tag+".tgz\"", { cwd: project });
 		});
 };

--- a/lib/release.js
+++ b/lib/release.js
@@ -17,7 +17,7 @@ module.exports = function(opts) {
 	var authorizedHeaders = { Authorization: 'token '+token };
 
 	logger.verbose("getting all releases");
-	return exists(opts.cwd+'/tmp/slug.tgz')
+	return exists(opts.cwd+'/.haikro/slug.tgz')
 		.then(function(exists) {
 			if (!exists) throw new Error('cannot find releaseable binary');
 		})
@@ -61,7 +61,7 @@ module.exports = function(opts) {
 				+ " -H 'Accept: application/vnd.github.manifold-preview' "
 				+ " -H 'Content-Type:application/gzip' "
 				+ " -H 'Authorization:"+authorizedHeaders.Authorization+"' "
-				+ " --data-binary @tmp/slug.tgz "
+				+ " --data-binary @.haikro/slug.tgz "
 				+ " \"https://uploads.github.com/repos/"+repository+"/releases/"+release+"/assets?name="+tag+".tgz\"", { cwd: project });
 		});
 };


### PR DESCRIPTION
Use .haikro instead of tmp as the temporary build file to avoid excluding legit directories named 'tmp'.

--

The` build.js` `tar` exclusion of 'tmp' excludes any directory named `tmp` on Mac OS X.

I'm using npmjs.org/tmp which creates a directory named `tmp` in `node_modules`.  This seems to be excluded from the release because of the `tar` excludes.

This names the tmp build directory something a little more specific to haikro.