### PR TITLE
At the start of the build phase ensure that .haikro-cache is empty

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -100,7 +100,7 @@ module.exports = function(options) {
 		readFile(opts.cwd+'/.slugignore', 'utf8'),
 		detectUbuntu(strict),
 		ensureJavaScriptEngineDownloaded(opts),
-		exec('mkdir -p .haikro-cache', opts)
+		exec('mkdir -p .haikro-cache && rm -rf .haikro-cache/*', opts)
 	])
 		.then(function(results) {
 			logger.info('making tarball');


### PR DESCRIPTION
...as well as existing, cleaning up after any previous runs.

In theory the `--exclude` logic for `tar` should have protected against this anyway.  I've tried manual tars with both bsdtar and gnutar and it's worked fine there, so my only guess is that the exclude logic isn't working correctly when passed in from node at some point... which sounds bad, but I can't pin it down :(