### PR TITLE
Ignore dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A tool to make + deploy node apps as self contained tarballs to Heroku.  [Read t
 npm install --save haikro
 ```
 
-I currently recommend installing **haikro** as a normal dependency instead of a `devDependency` even though strictly speaking it shouldn't be used in production to stop it being deleted by `npm prune --production`.
+I currently recommend installing **haikro** as a devDependency and you need not run `npm prune --production` as Haikro will effectively do this internally.
 
 ## Usage
 
@@ -26,9 +26,6 @@ deploy:
 	# Build steps
 	sass styles.scss public/styles.css
 	
-	# Remove devDependencies
-	npm prune --production
-
 	# Package+deploy
 	@./node_modules/.bin/haikro build deploy \
 		--app $(app) \

--- a/lib/build.js
+++ b/lib/build.js
@@ -118,9 +118,9 @@ module.exports = function(options) {
 			var tarOptions = results[0];
 			var slugContents = results[1];
 			var excludeList = results[2].map(function(devDependency) {
-				return "--exclude ./node_modules/" + devDependency + "/";
+				return "--exclude './node_modules/" + devDependency + "/*'";
 			});
-			excludeList.push('--exclude ./.haikro-cache');
+			excludeList.push("--exclude './.haikro-cache*'");
 			logger.verbose('ignoring', excludeList);
 
 			// GNU tar <1.28 does not support --exclude-from

--- a/lib/build.js
+++ b/lib/build.js
@@ -120,7 +120,7 @@ module.exports = function(options) {
 			var excludeList = results[2].map(function(devDependency) {
 				return "--exclude './node_modules/" + devDependency + "/*'";
 			});
-			excludeList.push("--exclude './.haikro-cache*'");
+			excludeList.push("--exclude './.haikro-cache/*'");
 			logger.verbose('ignoring', excludeList);
 
 			// GNU tar <1.28 does not support --exclude-from

--- a/lib/build.js
+++ b/lib/build.js
@@ -89,6 +89,13 @@ function ensureJavaScriptEngineDownloaded(opts) {
 		});
 }
 
+function getDevDependencies(opts) {
+	return packageJson(opts.cwd)
+		.then(function(data) {
+			return Object.keys(data.devDependencies || {});
+		});
+}
+
 module.exports = function(options) {
 	var strict = options.strict;
 	var project = options.project || process.cwd();
@@ -98,6 +105,7 @@ module.exports = function(options) {
 	return Promise.all([
 		detectTarOptions(),
 		readFile(opts.cwd+'/.slugignore', 'utf8'),
+		getDevDependencies(opts),
 		detectUbuntu(strict),
 		ensureJavaScriptEngineDownloaded(opts),
 		exec('mkdir -p .haikro-cache && rm -rf .haikro-cache/*', opts)
@@ -106,7 +114,11 @@ module.exports = function(options) {
 			logger.info('making tarball');
 			var tarOptions = results[0];
 			var slugContents = results[1];
-			var excludeList = ['--exclude ./.haikro-cache'];
+			var excludeList = results[2].map(function(devDependency) {
+				return "--exclude ./node_modules/" + devDependency + "/";
+			});
+			excludeList.push('--exclude ./.haikro-cache');
+			logger.verbose('ignoring', excludeList);
 
 			// GNU tar <1.28 does not support --exclude-from
 			if (slugContents) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -92,7 +92,10 @@ function ensureJavaScriptEngineDownloaded(opts) {
 function getDevDependencies(opts) {
 	return packageJson(opts.cwd)
 		.then(function(data) {
-			return Object.keys(data.devDependencies || {});
+			if (data) {
+				return Object.keys(data.devDependencies || {});
+			}
+			return [];
 		});
 }
 

--- a/test/fixtures/simple-app/node_modules/dep-test/test.txt
+++ b/test/fixtures/simple-app/node_modules/dep-test/test.txt
@@ -1,0 +1,1 @@
+this file should be here

--- a/test/fixtures/simple-app/node_modules/dev-dep-test/test.txt
+++ b/test/fixtures/simple-app/node_modules/dev-dep-test/test.txt
@@ -1,0 +1,1 @@
+this file shouldn't be here

--- a/test/fixtures/simple-app/package.json
+++ b/test/fixtures/simple-app/package.json
@@ -1,1 +1,8 @@
-{}
+{
+  "dependencies": {
+    "dep-test": "*"
+  },
+  "devDependencies": {
+    "dev-dep-test": "*"
+  }
+}

--- a/test/fixtures/simple-app/server.js
+++ b/test/fixtures/simple-app/server.js
@@ -1,7 +1,7 @@
 'use strict';
 var fs = require('fs');
 var dep = "this file wasn't here\n";
-var devDep = "this file wasn't here\o";
+var devDep = "this file wasn't here\n";
 try { dep = fs.readFileSync('./node_modules/dep-test/test.txt'); } catch(e) { }
 try { devDep = fs.readFileSync('./node_modules/dev-dep-test/test.txt'); } catch(e) { }
 

--- a/test/fixtures/simple-app/server.js
+++ b/test/fixtures/simple-app/server.js
@@ -1,5 +1,11 @@
 'use strict';
+var fs = require('fs');
+var dep = "this file wasn't here\n";
+var devDep = "this file wasn't here\o";
+try { dep = fs.readFileSync('./node_modules/dep-test/test.txt'); } catch(e) { }
+try { devDep = fs.readFileSync('./node_modules/dev-dep-test/test.txt'); } catch(e) { }
+
 require('http').createServer(function (req, res) {
 	res.writeHead(200, {'Content-Type': 'text/plain'});
-	res.end("Probably the simplest webserver in the world");
+	res.end("Probably the simplest webserver in the world\ndep:" + dep + "devDep:" + devDep);
 }).listen(process.env.PORT || 3000);

--- a/test/simple-deployment.test.js
+++ b/test/simple-deployment.test.js
@@ -51,6 +51,8 @@ describe('simple deployment', function() {
 			})
 			.then(function(body) {
 				assert(/the simplest webserver in the world/.test(body));
+				assert(/dep:this file should be here/.test(body));
+				assert(/devDep:this file wasn't here/.test(body));
 			})
 			.then(function() {
 				return destroy({


### PR DESCRIPTION
cc @commuterjoy @triblondon this means working directories will no longer be affected by haikro deploys. [this line](https://github.com/Financial-Times/next-build-tools/blob/master/tasks/deploy.js#L21) (and any other instances of `npm prune --production`) can be deleted.

Fixes #59 