### PR TITLE
Make prune optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ deploy:
 	
 	# Package+deploy
 	@haikro build deploy \
+	    --prune \
 		--app $(app) \
 		--heroku-token $(HEROKU_AUTH_TOKEN) \
 		--commit `git rev-parse HEAD`
@@ -91,6 +92,7 @@ If you want to use **iojs** just change your `package.json`'s `engines` to:-
 - `--heroku-token` - Heroku auth token
 - `--silent` - displays no debug info
 - `--verbose` - displays lot of debug info
+- `--prune` - remove devDependencies from deployed tarball
 
 # Licence
 This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/bin/haikro.js
+++ b/bin/haikro.js
@@ -35,7 +35,8 @@ if (argv._.indexOf('build') !== -1) {
 	promise = promise.then(function() {
 		return build({
 			project: argv.project,
-			strict: argv.strict
+			strict: argv.strict,
+			prune : (argv.prune || argv.P)
 		});
 	});
 }

--- a/lib/build.js
+++ b/lib/build.js
@@ -102,6 +102,7 @@ function getDevDependencies(opts) {
 module.exports = function(options) {
 	var strict = options.strict;
 	var project = options.project || process.cwd();
+	var prune = options.prune;
 	logger.debug('running for '+project);
 	var opts = { cwd: project };
 
@@ -117,12 +118,17 @@ module.exports = function(options) {
 			logger.info('making tarball');
 			var tarOptions = results[0];
 			var slugContents = results[1];
-			var excludeList = results[2].map(function(devDependency) {
+
+			// the --prune or -P flag must be specificed before haikro attempts to remove devDependencies
+			// as this is potentially destructive
+			// items in the slugignore will still be removed regardless of this flag
+			// todo [PW] Make this logic more intelligent
+			var excludeList = prune ? results[2].map(function(devDependency) {
 				return "--exclude './node_modules/" + devDependency + "/*'";
-			});
+			}) : [];
+
 			excludeList.push("--exclude './.haikro-cache/*'");
 			logger.verbose('ignoring', excludeList);
-
 			// GNU tar <1.28 does not support --exclude-from
 			if (slugContents) {
 				var slugIgnores = slugContents.split('\n').filter(Boolean).map(function(a) {


### PR DESCRIPTION
Automatically removing the dev dependencies is potentially problematic.  This pull request puts that feature behind a flag which defaults to off.  This does mean that unnecessary code will get deployed, although the .slugignore file is still respected.

I will deal with a better way of checking we remove the correct dependencies in a separate PR, after which we could remove or invert this option