### PR TITLE
Support (single) arbitrary process type

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you want to use **iojs** just change your `package.json`'s `engines` to:-
 - `--organization` - Which organization to create app in (when used with `haikro create`)
 - `--commit` - free text used to identify a release
 - `--heroku-token` - Heroku auth token
+- `--process-type` - Desired process type for Heroku app, defaults to `web`
 - `--silent` - displays no debug info
 - `--verbose` - displays lot of debug info
 

--- a/bin/haikro.js
+++ b/bin/haikro.js
@@ -66,7 +66,8 @@ if (argv._.indexOf('deploy') !== -1) {
 			commit: argv.commit,
 			project: argv.project || process.cwd(),
 			token: argv['heroku-token'],
-			useLegacyToken: !!argv.token
+			useLegacyToken: !!argv.token,
+			processType: argv['process-type']
 		});
 	});
 }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -12,6 +12,7 @@ module.exports = function(opts) {
 	var token = opts.token;
 	if (!token) throw new Error('please provide a heroku access token');
 	var commit = opts.commit;
+	var processType = opts.processType;
 
 	if (opts.useLegacyToken && token.indexOf("-") === -1) {
 		logger.warn("use of base64 encoded token is deprecated, please use raw auth:token");
@@ -26,21 +27,24 @@ module.exports = function(opts) {
 		'Content-Type': 'application/json',
 		'Authorization': token
 	};
-
+	
 	logger.info("creating slug tarball");
+	logger.verbose("expecting process type " + processType);
 	logger.verbose("trying to read start script from Procfile");
 	return readFile(project+"/Procfile", { encoding: 'UTF-8' })
-		.then(function(procfile) { return procfile.match(/web:(.*)/)[1]; })
+		.then(function(procfile) { return procfile.match(new RegExp(processType + ":(.*)"))[1]; })
 		.catch(function() {
 			logger.verbose("trying to read start script from package.json");
 			return packageJson(project)
 				.then(function(data) { return data.scripts.start; });
 		})
 		.then(function(script) {
+			var processTypes = {};
+			processTypes[processType] = 'export PATH="node_modules/.bin:node-linux-x64/bin:iojs-linux-x64/bin:$PATH"; ' + script
 			return fetch("https://api.heroku.com/apps/"+app+"/slugs", {
 					method: 'post',
 					headers: authorizedPostHeaders,
-					body: JSON.stringify({ process_types: { web: 'export PATH="node_modules/.bin:node-linux-x64/bin:iojs-linux-x64/bin:$PATH"; ' + script }, commit: commit })
+					body: JSON.stringify({ process_types: processTypes, commit: commit })
 				}).then(function(response) {
 					return response.json();
 				}).then(function(slug) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -12,7 +12,7 @@ module.exports = function(opts) {
 	var token = opts.token;
 	if (!token) throw new Error('please provide a heroku access token');
 	var commit = opts.commit;
-	var processType = opts.processType;
+	var processType = opts.processType || "web";
 
 	if (opts.useLegacyToken && token.indexOf("-") === -1) {
 		logger.warn("use of base64 encoded token is deprecated, please use raw auth:token");

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -40,7 +40,7 @@ module.exports = function(opts) {
 		})
 		.then(function(script) {
 			var processTypes = {};
-			processTypes[processType] = 'export PATH="node_modules/.bin:node-linux-x64/bin:iojs-linux-x64/bin:$PATH"; ' + script
+			processTypes[processType] = 'export PATH="node_modules/.bin:node-linux-x64/bin:iojs-linux-x64/bin:$PATH"; ' + script;
 			return fetch("https://api.heroku.com/apps/"+app+"/slugs", {
 					method: 'post',
 					headers: authorizedPostHeaders,


### PR DESCRIPTION
These changes are something of a first step towards supporting arbitrary process types, in that it only provides an option for specifying a single process type. This is sufficient for my use case (two Heroku apps, so I have two separate Procfiles: one with a `web` process, the other with a long-running `worker` process), and I imagine it would be useful for others as well.

If this sounds like something you'd like to merge, let me know and I'll add some tests.