### PR TITLE
Silence npm logs in parseable output

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -106,7 +106,7 @@ function ensureJavaScriptEngineDownloaded(opts) {
 function getDependencies(opts) {
 	return Promise.all([
 			glob('!(node_modules)/', opts),
-			shellpromise('npm ls --production --parseable', opts),
+			shellpromise('npm ls --production --parseable -s', opts),
 			glob('*', { dot: true, cwd: opts.cwd, nodir: true }),
 			exists(opts.cwd+'/node_modules/.bin')
 		])


### PR DESCRIPTION
Output from `npm ls --production --parseable` [here](https://github.com/matthew-andrews/haikro/blob/master/lib/build.js#L109) was being polluted with npm loglevel info output that was preventing the directory list from being parsed.