### PR TITLE
Fix the output of error messages from the Heroku API

### DIFF
--- a/lib/res-json.js
+++ b/lib/res-json.js
@@ -6,7 +6,7 @@ function heroku(res) {
 	} else {
 		return res.json()
 			.then(function(data) {
-				throw new Error("heroku error=" + data.id + " message=\"" + data.url + "\" url=\"" + data.url + "\"");
+				throw new Error("heroku error=" + data.id + " message=\"" + data.message + "\" url=\"" + data.url + "\"");
 			});
 	}
 }


### PR DESCRIPTION
JSON error responses from Heroku store the error message in the 'message' field.