### PR TITLE
use a more self-explanatory option for `-s`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -106,7 +106,7 @@ function ensureJavaScriptEngineDownloaded(opts) {
 function getDependencies(opts) {
 	return Promise.all([
 			glob('!(node_modules)/', opts),
-			shellpromise('npm ls --production --parseable -s', opts),
+			shellpromise('npm ls --production --parseable --loglevel=silent', opts),
 			glob('*', { dot: true, cwd: opts.cwd, nodir: true }),
 			exists(opts.cwd+'/node_modules/.bin')
 		])


### PR DESCRIPTION
We had some issues with `npm ls` earlier today, and it'd have helped our debugging if we had known what `-s` was earlier.