### PR TITLE
Display any errors returned by `npm ls --production --parseable`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -106,11 +106,14 @@ function ensureJavaScriptEngineDownloaded(opts) {
 function getDependencies(opts) {
 	return Promise.all([
 			glob('!(node_modules)/', opts),
-			shellpromise('npm ls --production --parseable --loglevel=silent', opts),
+			shellpromise('npm ls --production --parseable', opts),
 			glob('*', { dot: true, cwd: opts.cwd, nodir: true }),
 			exists(opts.cwd+'/node_modules/.bin')
 		])
 		.then(function(results) {
+			// Strip out anything that isn't a path e.g. loglevel info output
+			results[1] = results[1].replace(/^[^\/].+/m, '');
+
 			var nodeModules = results[1].trim().split("\n");
 			var deps = results[0]
 				.map(function(folder) { return './' + folder; });


### PR DESCRIPTION
There are a variety of scenarios in which `npm ls` will return a non-zero exit code and the output will include error messages. In order to aid with debugging it is useful to be able to see these error messages. The changes introduced in PR #105 had the effect of silencing errors completely.

This change ensures that if the `npm ls` command was successful, but the output contains some lines that aren't filepaths e.g. loglevel info output, they will be stripped out, but that in the case of `npm ls` returning an error, you will be able to see it in the output displayed by `shellpromise`.